### PR TITLE
GameEngine (lógica de juego)

### DIFF
--- a/lib/core/game_engine.dart
+++ b/lib/core/game_engine.dart
@@ -1,0 +1,65 @@
+import 'dart:math';
+import 'package:flutter/foundation.dart';
+import 'models/difficulty.dart';
+import 'models/game_status.dart';
+
+class GameEngine with ChangeNotifier {
+  GameEngine({Difficulty difficulty = Difficulty.easy}) : _difficulty = difficulty {
+    _reset();
+  }
+
+  final Random _rng = Random();
+  late int _secret;
+  late int _attemptsLeft;
+  Difficulty _difficulty;
+  GameStatus _status = GameStatus.playing;
+
+  final List<int> greaterGuesses = [];
+  final List<int> lessGuesses = [];
+
+  Difficulty get difficulty => _difficulty;
+  int get attemptsLeft => _attemptsLeft;
+  GameStatus get status => _status;
+  int get secret => _secret;
+
+  void setDifficulty(Difficulty newDifficulty) {
+    _difficulty = newDifficulty;
+    _reset();
+  }
+
+  /// Devuelve:
+  /// - `GameStatus.won`   si acertó
+  /// - `GameStatus.lost`  si se quedó sin intentos tras el guess
+  /// - `GameStatus.playing` si aún sigue
+  ///
+  /// Lanza [ArgumentError] si el valor está fuera de rango.
+  GameStatus guess(int value) {
+    if (value < _difficulty.min || value > _difficulty.max) {
+      throw ArgumentError('Value $value is out of range ${_difficulty.min}-${_difficulty.max}');
+    }
+    if (_status != GameStatus.playing) return _status;
+
+    if (value == _secret) {
+      _status = GameStatus.won;
+    } else {
+      _attemptsLeft--;
+      if (value > _secret) {
+        greaterGuesses.add(value);
+      } else {
+        lessGuesses.add(value);
+      }
+      if (_attemptsLeft == 0) _status = GameStatus.lost;
+    }
+    notifyListeners();
+    return _status;
+  }
+
+  void _reset() {
+    greaterGuesses.clear();
+    lessGuesses.clear();
+    _secret = _rng.nextInt(_difficulty.max - _difficulty.min + 1) + _difficulty.min;
+    _attemptsLeft = _difficulty.attempts;
+    _status = GameStatus.playing;
+    notifyListeners();
+  }
+}

--- a/lib/core/models/difficulty.dart
+++ b/lib/core/models/difficulty.dart
@@ -1,0 +1,26 @@
+enum Difficulty { easy, medium, hard, extreme }
+
+extension DifficultyConfig on Difficulty {
+  int get min => 1;
+
+  int get max => switch (this) {
+    Difficulty.easy => 10,
+    Difficulty.medium => 20,
+    Difficulty.hard => 100,
+    Difficulty.extreme => 1000,
+  };
+
+  int get attempts => switch (this) {
+    Difficulty.easy => 5,
+    Difficulty.medium => 8,
+    Difficulty.hard => 15,
+    Difficulty.extreme => 25,
+  };
+
+  String get label => switch (this) {
+    Difficulty.easy => 'Easy',
+    Difficulty.medium => 'Medium',
+    Difficulty.hard => 'Hard',
+    Difficulty.extreme => 'Extreme',
+  };
+}

--- a/lib/core/models/game_status.dart
+++ b/lib/core/models/game_status.dart
@@ -1,0 +1,1 @@
+enum GameStatus { playing, won, lost }

--- a/test/game_engine_test.dart
+++ b/test/game_engine_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:adivina_el_numero/core/game_engine.dart';
+import 'package:adivina_el_numero/core/models/difficulty.dart';
+import 'package:adivina_el_numero/core/models/game_status.dart';
+
+void main() {
+  group('GameEngine', () {
+    test('generates secret within range and attempts count', () {
+      final engine = GameEngine(difficulty: Difficulty.medium);
+      expect(engine.secret, inInclusiveRange(1, 20));
+      expect(engine.attemptsLeft, 8);
+      expect(engine.status, GameStatus.playing);
+    });
+
+    test('win scenario', () {
+      final engine = GameEngine();
+      final secret = engine.secret;
+      final result = engine.guess(secret);
+      expect(result, GameStatus.won);
+      expect(engine.status, GameStatus.won);
+    });
+
+    test('lose scenario after max attempts', () {
+      final engine = GameEngine(difficulty: Difficulty.easy);
+      final wrong = engine.secret == engine.difficulty.max
+          ? engine.difficulty.min
+          : engine.difficulty.max;
+      for (var i = 0; i < engine.difficulty.attempts; i++) {
+        engine.guess(wrong);
+      }
+      expect(engine.status, GameStatus.lost);
+      expect(engine.attemptsLeft, 0);
+    });
+
+    test('throws if value out of range', () {
+      final engine = GameEngine();
+      expect(() => engine.guess(0), throwsArgumentError);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #3

GameEngine core logic:
- Difficulty enum + ranges & attempts
- GameStatus enum
- GameEngine (ChangeNotifier) with guess/reset
- Unit tests covering win, lose, range validation